### PR TITLE
spotfleet: use new AmazonEC2SpotFleetTaggingRole

### DIFF
--- a/templates/compute/spotfleet/template.yaml
+++ b/templates/compute/spotfleet/template.yaml
@@ -114,7 +114,7 @@ Resources:
         }
       Path: /
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
 
   ECSRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
`AmazonEC2SpotFleetRole` appears to be deprecated, replaced by `AmazonEC2SpotFleetTaggingRole`.

Here's an email from AWS:

> We have identified that one or more IAM user(s) or role(s) in your account (listed below) uses the AmazonEC2SpotFleetRole managed IAM policy. As part of service improvements we regularly update our managed policies. A newer version of the policy, AmazonEC2SpotFleetTaggingRole, is now available.
> 
> The new managed policy provides the same level of support that grants the Spot Fleet permission to bid on, launch and terminate instances on your behalf. In addition, it also provides support to add Tags to your created Spot fleet entities at the time of creation.
> 
> Please update your IAM user(s) or role(s) to use the new policy by following the instructions located here https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage-attach-detach.html
> 
> For details on deprecated AWS managed IAM policies, refer to https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-deprecated.html